### PR TITLE
Remove unistring_app module (unnecessary).

### DIFF
--- a/src/unistring.app.src
+++ b/src/unistring.app.src
@@ -7,6 +7,5 @@
                   kernel,
                   stdlib
                  ]},
-  {mod, { unistring_app, []}},
   {env, []}
  ]}.

--- a/src/unistring_app.erl
+++ b/src/unistring_app.erl
@@ -1,2 +1,0 @@
--module(unistring_app).
--vsn("0.1.0").


### PR DESCRIPTION
It should be best to have this as a library.  It doesn't need a supervision hierarchy.
